### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/active.cabal
+++ b/active.cabal
@@ -23,7 +23,7 @@ library
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.16,
                        semigroupoids >= 1.2 && < 5.0,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        linear >= 1.10 && < 1.11
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -35,7 +35,7 @@ test-suite active-tests
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.16,
                        semigroupoids >= 1.2 && < 5.0,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        linear >= 1.10 && < 1.11,
                        QuickCheck >= 2.4.2 && < 2.8
     hs-source-dirs:    src, test


### PR DESCRIPTION
Allow `active` to use the latest version of `lens` (4.5).
