### PR TITLE
Bump lens, linear upper version bounds

### DIFF
--- a/active.cabal
+++ b/active.cabal
@@ -24,7 +24,7 @@ library
                        semigroups >= 0.1 && < 0.16,
                        semigroupoids >= 1.2 && < 5.0,
                        lens >= 4.0 && < 4.7,
-                       linear >= 1.10 && < 1.15
+                       linear >= 1.10 && < 1.16
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -36,7 +36,7 @@ test-suite active-tests
                        semigroups >= 0.1 && < 0.16,
                        semigroupoids >= 1.2 && < 5.0,
                        lens >= 4.0 && < 4.7,
-                       linear >= 1.11.3 && < 1.15,
+                       linear >= 1.11.3 && < 1.16,
                        QuickCheck >= 2.4.2 && < 2.8
     hs-source-dirs:    src, test
     default-language:  Haskell2010


### PR DESCRIPTION
Allow `active` to be built using the latest versions of `lens` (4.6) and `linear` (1.13).
