### PR TITLE
Bump vector-space upper version bounds

### DIFF
--- a/active.cabal
+++ b/active.cabal
@@ -23,7 +23,7 @@ library
                        array >= 0.3 && < 0.6,
                        semigroups >= 0.1 && < 0.17,
                        semigroupoids >= 1.2 && < 4.3,
-                       vector-space >= 0.8 && < 0.9,
+                       vector-space >= 0.8 && < 0.10,
                        newtype >= 0.2 && < 0.3
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -35,7 +35,7 @@ test-suite active-tests
                        array >= 0.3 && < 0.6,
                        semigroups >= 0.1 && < 0.17,
                        semigroupoids >= 1.2 && < 4.3,
-                       vector-space >= 0.8 && < 0.9,
+                       vector-space >= 0.8 && < 0.10,
                        newtype >= 0.2 && < 0.3,
 
                        QuickCheck >= 2.4.2 && < 2.8


### PR DESCRIPTION
The version of `active` on Hackage doesn't support `vector-space-0.9`.