### PR TITLE
Relax base bound for GHC 8.2

### DIFF
--- a/active.cabal
+++ b/active.cabal
@@ -32,7 +32,7 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.10,
+    build-depends:     base >= 4.0 && < 4.11,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.19,
                        semigroupoids >= 1.2 && < 5.3,


### PR DESCRIPTION
GHC 8.2 will ship with base-4.10

FWIW the testsuite passes after.