### PR TITLE
Fix Travis build: isSuccess is now part of QuickCheck

### DIFF
--- a/test/active-tests.hs
+++ b/test/active-tests.hs
@@ -25,8 +25,6 @@ main = do
   results <- mapM (\(s,t) -> printf "%-40s" s >> t) tests
   unless (all isSuccess results) exitFailure
   where
-    isSuccess (Success{}) = True
-    isSuccess _           = False
     qc x = quickCheckWithResult (stdArgs { maxSuccess = 200 }) x
     tests = [ ("era/start",                   qc prop_era_start          )
             , ("era/end",                     qc prop_era_end            )


### PR DESCRIPTION
The Travis build for the `release` branch is failing due to redefining the `isSuccess` function in the test suite. This PR removes the local definition of that function in favor of the one from QuickCheck, allowing the Travis build to pass.

AFAICT, `isSuccess` has been part of QuickCheck since 2008 (cf. https://github.com/nick8325/quickcheck/commit/86154797ad128bab7643bd84944be1044750addb).

(PS: I'm not sure if the `release` branch is where changes to help ghc-8.8.x migration belong, but I noticed that an ocharles patch was recently merged there, so I assumed it's where that's taking place. If not, feel free to ignore / decline this PR.)