### PR TITLE
Additive instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ ActiveDiagrams
 semantics/diagrams/*
 semantics/FARM/diagrams/*
 .diagrams-cache
+
+stack.yaml.lock
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: haskell
 
 env:
   matrix:
-    - GHCVER=7.6.3 CABALVER=1.18
     - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.2 CABALVER=1.22
     - GHCVER=8.0.1 CABALVER=1.24

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: haskell
 env:
   matrix:
     - GHCVER=7.8.4 CABALVER=1.18
-    - GHCVER=7.10.2 CABALVER=1.22
-    - GHCVER=8.0.1 CABALVER=1.24
+    - GHCVER=7.10.3 CABALVER=1.22
+    - GHCVER=8.0.2 CABALVER=1.24
     - GHCVER=8.2.2 CABALVER=2.0
-    - GHCVER=8.4.1 CABALVER=2.2
+    - GHCVER=8.4.2 CABALVER=2.2
+    - GHCVER=8.6.1 CABALVER=2.4
     - GHCVER=head CABALVER=head
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - GHCVER=8.2.2 CABALVER=2.0
     - GHCVER=8.4.2 CABALVER=2.2
     - GHCVER=8.6.1 CABALVER=2.4
+    - GHCVER=8.8.1 CABALVER=3.0
     - GHCVER=head CABALVER=head
 
 matrix:

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+## [0.2.0.14](https://github.com/diagrams/active/tree/v0.2.0.14) (2019-10-19)
+
+- Updates for GHC 8.8
+
 ## [0.2.0.13](https://github.com/diagrams/active/tree/v0.2.0.13) (2017-05-16)
 
 - fix for `lens-4.15.2`

--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,9 @@ Hackage revisions:
 - r4:
     - allow `base-4.11` (GHC 8.4)
 
+- r8:
+    - allow `QuickCheck-2.13`
+
 ## [0.2.0.12](https://github.com/diagrams/active/tree/v0.2.0.12) (2016-10-14)
 
 - allow `lens-4.15`

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,10 @@ Hackage revisions:
 - r8:
     - allow `QuickCheck-2.13`
 
+- r9:
+    - allow `lens-4.18`
+    - allow `semigroups-0.19`
+
 ## [0.2.0.12](https://github.com/diagrams/active/tree/v0.2.0.12) (2016-10-14)
 
 - allow `lens-4.15`

--- a/active.cabal
+++ b/active.cabal
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       1.18
 extra-source-files:  CHANGES, README.markdown, diagrams/*.svg
 extra-doc-files:     diagrams/*.svg
-tested-with:         GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.1
+tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.6.1
 bug-reports:         https://github.com/diagrams/active/issues
 source-repository head
   type:     git

--- a/active.cabal
+++ b/active.cabal
@@ -23,7 +23,7 @@ library
   build-depends:       base >= 4.0 && < 4.12,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.19,
-                       semigroupoids >= 1.2 && < 5.3,
+                       semigroupoids >= 1.2 && < 5.4,
                        lens >= 4.0 && < 4.17,
                        linear >= 1.14 && < 1.21
   hs-source-dirs:      src

--- a/active.cabal
+++ b/active.cabal
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       1.18
 extra-source-files:  CHANGES, README.markdown, diagrams/*.svg
 extra-doc-files:     diagrams/*.svg
-tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.6.1
+tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.6.1, GHC == 8.8.1
 bug-reports:         https://github.com/diagrams/active/issues
 source-repository head
   type:     git

--- a/active.cabal
+++ b/active.cabal
@@ -1,5 +1,5 @@
 name:                active
-version:             0.2.0.14
+version:             0.2.0.15
 synopsis:            Abstractions for animation
 description:         "Active" abstraction for animated things with finite start and end times.
 license:             BSD3
@@ -25,7 +25,7 @@ library
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
                        lens >= 4.0 && < 4.19,
-                       linear >= 1.14 && < 1.21
+                       linear >= 1.14 && < 1.22
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -37,7 +37,7 @@ test-suite active-tests
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
                        lens >= 4.0 && < 4.19,
-                       linear >= 1.14 && < 1.21,
+                       linear >= 1.14 && < 1.22,
                        QuickCheck >= 2.9 && < 2.14
     other-modules:     Data.Active
     hs-source-dirs:    src, test

--- a/active.cabal
+++ b/active.cabal
@@ -20,11 +20,11 @@ source-repository head
 
 library
   exposed-modules:     Data.Active
-  build-depends:       base >= 4.0 && < 4.12,
+  build-depends:       base >= 4.0 && < 4.13,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.19,
                        semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 4.17,
+                       lens >= 4.0 && < 4.18,
                        linear >= 1.14 && < 1.21
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -32,13 +32,13 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.12,
+    build-depends:     base >= 4.0 && < 4.13,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.19,
                        semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 4.17,
+                       lens >= 4.0 && < 4.18,
                        linear >= 1.14 && < 1.21,
-                       QuickCheck >= 2.9 && < 2.12
+                       QuickCheck >= 2.9 && < 2.13
     other-modules:     Data.Active
     hs-source-dirs:    src, test
     default-language:  Haskell2010

--- a/active.cabal
+++ b/active.cabal
@@ -22,9 +22,9 @@ library
   exposed-modules:     Data.Active
   build-depends:       base >= 4.0 && < 4.13,
                        vector >= 0.10,
-                       semigroups >= 0.1 && < 0.19,
+                       semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 4.18,
+                       lens >= 4.0 && < 4.19,
                        linear >= 1.14 && < 1.21
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -34,9 +34,9 @@ test-suite active-tests
     main-is:           active-tests.hs
     build-depends:     base >= 4.0 && < 4.13,
                        vector >= 0.10,
-                       semigroups >= 0.1 && < 0.19,
+                       semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 4.18,
+                       lens >= 4.0 && < 4.19,
                        linear >= 1.14 && < 1.21,
                        QuickCheck >= 2.9 && < 2.14
     other-modules:     Data.Active

--- a/active.cabal
+++ b/active.cabal
@@ -32,7 +32,7 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.11,
+    build-depends:     base >= 4.0 && < 4.12,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.19,
                        semigroupoids >= 1.2 && < 5.3,

--- a/active.cabal
+++ b/active.cabal
@@ -35,7 +35,7 @@ test-suite active-tests
     build-depends:     base >= 4.0 && < 4.12,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.19,
-                       semigroupoids >= 1.2 && < 5.3,
+                       semigroupoids >= 1.2 && < 5.4,
                        lens >= 4.0 && < 4.17,
                        linear >= 1.14 && < 1.21,
                        QuickCheck >= 2.9 && < 2.12

--- a/active.cabal
+++ b/active.cabal
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       1.18
 extra-source-files:  CHANGES, README.markdown, diagrams/*.svg
 extra-doc-files:     diagrams/*.svg
-tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.1
+tested-with:         GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.1
 bug-reports:         https://github.com/diagrams/active/issues
 source-repository head
   type:     git

--- a/active.cabal
+++ b/active.cabal
@@ -20,11 +20,11 @@ source-repository head
 
 library
   exposed-modules:     Data.Active
-  build-depends:       base >= 4.0 && < 4.14,
+  build-depends:       base >= 4.0 && < 4.16,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 4.19,
+                       lens >= 4.0 && < 4.20,
                        linear >= 1.14 && < 1.22
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -32,7 +32,7 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.14,
+    build-depends:     base >= 4.0 && < 4.16,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,

--- a/active.cabal
+++ b/active.cabal
@@ -1,5 +1,5 @@
 name:                active
-version:             0.2.0.13
+version:             0.2.0.14
 synopsis:            Abstractions for animation
 description:         "Active" abstraction for animated things with finite start and end times.
 license:             BSD3

--- a/active.cabal
+++ b/active.cabal
@@ -38,7 +38,7 @@ test-suite active-tests
                        semigroupoids >= 1.2 && < 5.4,
                        lens >= 4.0 && < 4.18,
                        linear >= 1.14 && < 1.21,
-                       QuickCheck >= 2.9 && < 2.13
+                       QuickCheck >= 2.9 && < 2.14
     other-modules:     Data.Active
     hs-source-dirs:    src, test
     default-language:  Haskell2010

--- a/active.cabal
+++ b/active.cabal
@@ -20,7 +20,7 @@ source-repository head
 
 library
   exposed-modules:     Data.Active
-  build-depends:       base >= 4.0 && < 4.13,
+  build-depends:       base >= 4.0 && < 4.14,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
@@ -32,7 +32,7 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.13,
+    build-depends:     base >= 4.0 && < 4.14,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,

--- a/active.cabal
+++ b/active.cabal
@@ -9,7 +9,7 @@ maintainer:          byorgey@gmail.com
 copyright:           (c) 2011-2015 Brent Yorgey
 category:            Data
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       1.18
 extra-source-files:  CHANGES, README.markdown, diagrams/*.svg
 extra-doc-files:     diagrams/*.svg
 tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.1

--- a/src/Data/Active.hs
+++ b/src/Data/Active.hs
@@ -178,11 +178,6 @@ toTime = Time
 fromTime :: Time n -> n
 fromTime = unTime
 
-instance Affine Time where
-  type Diff Time = Duration
-  (Time t1) .-. (Time t2) = Duration (t1 - t2)
-  (Time t) .+^ (Duration d) = Time (t + d)
-
 -- instance Deadline Time a where
 --   -- choose tm deadline (if before / at deadline) (if after deadline)
 --   choose t1 t2 a b = if t1 <= t2 then a else b
@@ -217,6 +212,15 @@ instance Num n => Semigroup (Duration n) where
 instance Num n => Monoid (Duration n) where
   mappend = (<>)
   mempty  = 0
+
+
+instance Affine Time where
+  -- It is important that this deffinition comes *after*
+  -- the 'Additive' instance of 'Duration' to build with GHC-9.0
+  type Diff Time = Duration
+  (Time t1) .-. (Time t2) = Duration (t1 - t2)
+  (Time t) .+^ (Duration d) = Time (t + d)
+
 
 -- | An @Era@ is a concrete span of time, that is, a pair of times
 --   representing the start and end of the era. @Era@s form a

--- a/test/active-tests.hs
+++ b/test/active-tests.hs
@@ -25,8 +25,6 @@ main = do
   results <- mapM (\(s,t) -> printf "%-40s" s >> t) tests
   unless (all isSuccess results) exitFailure
   where
-    isSuccess (Success{}) = True
-    isSuccess _           = False
     qc x = quickCheckWithResult (stdArgs { maxSuccess = 200 }) x
     tests = [ ("era/start",                   qc prop_era_start          )
             , ("era/end",                     qc prop_era_end            )


### PR DESCRIPTION
Moved the `Additive` instance for `Duration` to allow building with newer versions of `ghc`. The `Additive` definition needs to come before the `Affine` defintion of `Time`. This is dure to chages in the type checker related to types `(* -> *)`.