### PR TITLE
Support GHC 9.0 on pre-rewrite version

### DIFF
--- a/active.cabal
+++ b/active.cabal
@@ -1,5 +1,5 @@
 name:                active
-version:             0.2.0.14
+version:             0.2.0.15
 synopsis:            Abstractions for animation
 description:         "Active" abstraction for animated things with finite start and end times.
 license:             BSD3
@@ -36,9 +36,9 @@ test-suite active-tests
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.20,
                        semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 4.20,
+                       lens >= 4.0 && < 5.1,
                        linear >= 1.14 && < 1.22,
-                       QuickCheck >= 2.9 && < 2.14
+                       QuickCheck >= 2.9 && < 2.15
     other-modules:     Data.Active
     hs-source-dirs:    src, test
     default-language:  Haskell2010

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
 packages: *.cabal
+
+tests: True

--- a/src/Data/Active.hs
+++ b/src/Data/Active.hs
@@ -189,15 +189,13 @@ fromTime = unTime
 newtype Duration n = Duration n
   deriving (Eq, Ord, Show, Read, Enum, Num, Fractional, Real, RealFrac, Functor)
 
-makeWrapped ''Duration
-
 -- | A convenient wrapper function to convert a numeric value into a duration.
 toDuration :: n -> Duration n
 toDuration = Duration
 
 -- | A convenient unwrapper function to turn a duration into a numeric value.
 fromDuration :: Duration n -> n
-fromDuration = op Duration
+fromDuration (Duration n) = n
 
 instance Applicative Duration where
   pure = Duration
@@ -219,6 +217,8 @@ instance Affine Time where
   type Diff Time = Duration
   (Time t1) .-. (Time t2) = Duration (t1 - t2)
   (Time t) .+^ (Duration d) = Time (t + d)
+
+makeWrapped ''Duration
 
 -- | An @Era@ is a concrete span of time, that is, a pair of times
 --   representing the start and end of the era. @Era@s form a


### PR DESCRIPTION
This is not a real PR to master. In a similar spirit as https://github.com/diagrams/active/pull/33, I'd like to update `diagrams-lib` to support GHC 9.0, which means `active` needs to support GHC 9.0; but `diagrams-lib` doesn't yet support `active-3` (i.e. `master` of this repo). I propose making a release of the pre-rewrite `active` library, but updated to support GHC 9.0.