### PR TITLE
Bump dependencies and CI for GHC 9.6; bump CI to ubuntu-20.04

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.15.20230321
 #
-# REGENDATA ("0.13.20211116",["github","active.cabal"])
+# REGENDATA ("0.15.20230321",["github","active.cabal"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,15 +28,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.6.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -66,18 +76,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -95,13 +105,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -160,7 +170,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -195,8 +205,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -220,8 +230,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/active.cabal
+++ b/active.cabal
@@ -18,8 +18,7 @@ copyright:           (c) 2011-2017 Brent Yorgey
 category:            Data
 build-type:          Custom
 cabal-version:       1.18
-extra-source-files:  CHANGES, README.markdown, diagrams/*.svg
-extra-doc-files:     diagrams/*.svg
+extra-doc-files:     CHANGES, README.markdown, diagrams/*.svg
 bug-reports:         https://github.com/diagrams/active/issues
 
 tested-with:
@@ -39,7 +38,7 @@ source-repository head
 custom-setup
  setup-depends:
    base >= 4.7 && < 5,
-   Cabal,
+   Cabal < 4,
    cabal-doctest >= 1 && <1.1
 
 library
@@ -62,6 +61,6 @@ test-suite doctests
   type:                exitcode-stdio-1.0
   main-is:             active-doctest.hs
   build-depends:       base,
-                       doctest
+                       doctest < 1
   hs-source-dirs:      test
   default-language:    Haskell2010

--- a/active.cabal
+++ b/active.cabal
@@ -23,12 +23,14 @@ extra-doc-files:     diagrams/*.svg
 bug-reports:         https://github.com/diagrams/active/issues
 
 tested-with:
-   GHC == 8.4.4
-   GHC == 8.6.5
-   GHC == 8.8.4
+   GHC == 9.6.1
+   GHC == 9.4.4
+   GHC == 9.2.7
+   GHC == 9.0.2
    GHC == 8.10.7
-   GHC == 9.0.1
-   GHC == 9.2.1
+   GHC == 8.8.4
+   GHC == 8.6.5
+   GHC == 8.4.4
 
 source-repository head
   type:     git
@@ -36,7 +38,7 @@ source-repository head
 
 custom-setup
  setup-depends:
-   base >= 4.7 && < 4.17,
+   base >= 4.7 && < 5,
    Cabal,
    cabal-doctest >= 1 && <1.1
 
@@ -48,11 +50,11 @@ library
                        FlexibleInstances,
                        GADTSyntax,
                        KindSignatures
-  build-depends:       base       >= 4.11 && < 5.0,
-                       bifunctors >= 5.4  && < 5.6,
+  build-depends:       base       >= 4.11 && < 5,
+                       bifunctors >= 5.4  && < 5.7,
                        semigroups >= 0.1  && < 0.21,
-                       vector     >= 0.10 && < 0.13,
-                       linear     >= 1.14 && < 1.22
+                       vector     >= 0.10 && < 0.14,
+                       linear     >= 1.14 && < 1.23
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
- ubuntu-18.04 has reached EOL
- package builds with bumps to latest versions on GHC 9.6.1

Needs hackage revision.
