### PR TITLE
Reform .cabal file & bump dependencies and CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,14 +8,22 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220808
+# version: 0.15.20230321
 #
-# REGENDATA ("0.15.20220808",["github","active.cabal"])
+# REGENDATA ("0.15.20230321",["github","active.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - release
+      - ci-*
+  pull_request:
+    branches:
+      - master
+      - release
+      - ci-*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -28,14 +36,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.6.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -91,18 +104,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -120,13 +133,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -185,7 +198,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -220,8 +233,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -245,8 +258,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/active.cabal
+++ b/active.cabal
@@ -1,3 +1,4 @@
+cabal-version:       1.18
 name:                active
 version:             0.2.0.16
 synopsis:            Abstractions for animation
@@ -7,23 +8,36 @@ license-file:        LICENSE
 author:              Brent Yorgey
 maintainer:          byorgey@gmail.com
 copyright:           (c) 2011-2015 Brent Yorgey
+bug-reports:         https://github.com/diagrams/active/issues
 category:            Data
 build-type:          Simple
-cabal-version:       1.18
-extra-source-files:  CHANGES, README.markdown, diagrams/*.svg
-extra-doc-files:     diagrams/*.svg
-tested-with:         GHC ==7.8.4 || ==7.10.3 || ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.1
-bug-reports:         https://github.com/diagrams/active/issues
+
+extra-doc-files:     CHANGES, README.markdown, diagrams/*.svg
+
+tested-with:
+  GHC ==7.8.4
+   || ==7.10.3
+   || ==8.0.2
+   || ==8.2.2
+   || ==8.4.4
+   || ==8.6.5
+   || ==8.8.4
+   || ==8.10.7
+   || ==9.0.2
+   || ==9.2.7
+   || ==9.4.4
+   || ==9.6.1
+
 source-repository head
   type:     git
   location: https://github.com/diagrams/active.git
 
 library
   exposed-modules:     Data.Active
-  build-depends:       base >= 4.0 && < 4.18,
+  build-depends:       base >= 4.0 && < 4.19,
                        vector >= 0.10,
                        semigroups >= 0.1 && < 0.21,
-                       semigroupoids >= 1.2 && < 5.4,
+                       semigroupoids >= 1.2 && < 6.1,
                        lens >= 4.0 && < 5.3,
                        linear >= 1.14 && < 1.23
   hs-source-dirs:      src
@@ -32,13 +46,11 @@ library
 test-suite active-tests
     type:              exitcode-stdio-1.0
     main-is:           active-tests.hs
-    build-depends:     base >= 4.0 && < 4.18,
-                       vector >= 0.10,
-                       semigroups >= 0.1 && < 0.21,
-                       semigroupoids >= 1.2 && < 5.4,
-                       lens >= 4.0 && < 5.3,
-                       linear >= 1.14 && < 1.23,
+    build-depends:     active,
+                       base,
+                       linear,
+                       semigroups,
+                         -- semigroups needed for GHC 7.x only
                        QuickCheck >= 2.9 && < 2.15
-    other-modules:     Data.Active
-    hs-source-dirs:    src, test
+    hs-source-dirs:    test
     default-language:  Haskell2010

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,1 @@
+branches: master release ci-*


### PR DESCRIPTION
Reform .cabal file: disentangle test-suite from library, bumps
- bump base for GHC 9.6
- bump semigroupoids to latest (6.0)
- make test-suite depend on library rather than recompiling it
- remove duplicate bounds declarations for dependencies in test-suite
- remove duplication between extra-doc/source-files

Bump CI to latest GHCs
- restrict to relevant branches